### PR TITLE
fix: GH Action CI Output excluded Markdown

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Extract Web Scraper Output Files
         run: |
           docker cp ${{ env.WEB_SCRAPER_NAME }}:${{ env.APP_DIR }}/output.json NCSC-CAF-${{ env.RELEASE_TAG_SLUG }}.json
+          docker cp ${{ env.WEB_SCRAPER_NAME }}:${{ env.APP_DIR }}/output.md NCSC-CAF-${{ env.RELEASE_TAG_SLUG }}.md
           docker cp ${{ env.WEB_SCRAPER_NAME }}:${{ env.APP_DIR }}/output.log NCSC-CAF-${{ env.RELEASE_TAG_SLUG }}.log
           echo "OUTPUT_JSON=NCSC-CAF-${{ env.RELEASE_TAG_SLUG }}.json" >> $GITHUB_OUTPUT
+          echo "OUTPUT_MD=NCSC-CAF-${{ env.RELEASE_TAG_SLUG }}.md" >> $GITHUB_OUTPUT
           echo "OUTPUT_LOG=NCSC-CAF-${{ env.RELEASE_TAG_SLUG }}.log" >> $GITHUB_OUTPUT
         id: extract_outputs
       
@@ -53,6 +55,12 @@ jobs:
         with:
           name: ${{ steps.extract_outputs.outputs.output_json }}
           path: ${{ steps.extract_outputs.outputs.output_json }}
+
+      - name: Upload Web Scraper Output Markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.extract_outputs.outputs.output_md }}
+          path: ${{ steps.extract_outputs.outputs.output_md }}
         
       - name: Upload Web Scraper Output Log
         uses: actions/upload-artifact@v4
@@ -66,4 +74,5 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG_SLUG }}
           files: |
             ${{ steps.extract_outputs.outputs.output_json }}
+            ${{ steps.extract_outputs.outputs.output_md }}
             ${{ steps.extract_outputs.outputs.output_log }}

--- a/main.py
+++ b/main.py
@@ -377,7 +377,7 @@ class CAF(pydantic.BaseModel):
 
         # version number is the text of the parent div
         # as it doesn't have it's own tag, extract all test, and get the final one (expected to be the version number)
-        return version_heading_tag.parent.css("::text").getall()[-1]
+        return version_heading_tag.parent.css("::text").getall()[-1].strip()
 
     @pydantic.computed_field()
     @functools.cached_property
@@ -490,7 +490,7 @@ def main(output_filename_stem: Path) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Scrape the NCSC CAF site, and extract the relevant information, presenting it as a structured JSON document.",
+        description="Scrape the NCSC CAF site, and extract the relevant information, presenting it as a structured document.",
     )
     parser.add_argument(
         "-o",


### PR DESCRIPTION
Include output.md in CI outputs uploaded as asset to release

A whitespace fix is made to the document version as well (leading whitespace)