### PR TITLE
fix: Update description header locator lambda

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    }
+  }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,13 @@ jobs:
             exit 1
           fi
 
+      - name: Check Web Scraper Output Log For Warnings
+        run: |
+          if grep -q "WARNING" "${{ steps.extract_outputs.outputs.output_log }}"; then
+            echo "Web scraper encountered an warning. This is typical for when the scraper fails to locate an element to extact. Check the log for details."
+            exit 1
+          fi
+
       - name: release-downloader
         uses: robinraju/release-downloader@v1.13
         with:

--- a/main.py
+++ b/main.py
@@ -165,7 +165,7 @@ class Principle(pydantic.BaseModel):
     def description(self) -> list[str]:
         description_section = self.content.find(
             "section",
-            lambda s: s.attrib.get("data-js-jumplinks-section-label", "").strip() == "Description",
+            lambda s: s.attrib.get("data-js-jumplinks-section-label", "").startswith("Description"),
         )
         if description_section is None:
             logger.warning(f"Unable to determine description for {self.link}")


### PR DESCRIPTION
NCSC Principe Desciption section heading has been changed from "Description" to a mized set of the following:
- "Description"
- "Description of principle"
- "Description&nbsp;of principle"

Which caused the parser to fail to locate the description start for some principle pages.

The locator lambda is criteria is loosed to simply look for a string begining with "Description"

This also updates the CI to check the log for warnings (as well as errors) to avoid publishing a release where the scraper has failed to extract from the page.